### PR TITLE
Adding HISTORY.rst to manifest for PyPi packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 # Include the MIT license file
 include LICENSE
+include HISTORY.rst


### PR DESCRIPTION
Installation of pyecobee via pip failed because HISTORY.rst is not included in the package because it's not listed in MANIFEST.in. setup.py attempts to read the HISTORY.rst file.

Searching for pyecobee==1.2.1
Reading https://pypi.python.org/simple/pyecobee/
Downloading https://pypi.python.org/packages/80/da/e9c94a250d344058938a25c6d62f4e25c9eafee00c92f748c00e41aa9363/pyecobee-1.2.1.tar.gz#md5=6963f94a5d533dfe6d5445b639eb493e
Best match: pyecobee 1.2.1
Processing pyecobee-1.2.1.tar.gz
Writing /tmp/easy_install-h5d61pls/pyecobee-1.2.1/setup.cfg
Running pyecobee-1.2.1/setup.py -q bdist_egg --dist-dir /tmp/easy_install-h5d61pls/pyecobee-1.2.1/egg-dist-tmp-yus4jiq9
error: [Errno 2] No such file or directory: 'HISTORY.rst'
The command 'python setup.py install' returned a non-zero code: 1
