### PR TITLE
Adding HISTORY.rst to manifest for PyPi packaging

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 # Include the MIT license file
 include LICENSE
+include HISTORY.rst


### PR DESCRIPTION
I think the previous pull request for this ( #2 ) may have been mistakenly closed instead of merged. This commit allows proper installation of pyecobee from pip.